### PR TITLE
Add first and last page buttons to transaction page

### DIFF
--- a/src/client/components/PageNavigation.tsx
+++ b/src/client/components/PageNavigation.tsx
@@ -3,8 +3,7 @@ import { queryTypes, useQueryState } from 'next-usequerystate'
 import React from 'react'
 import { FiArrowLeft, FiArrowRight } from 'react-icons/fi'
 import { MdFirstPage, MdLastPage} from 'react-icons/md'
-import { useTransactionPage } from 'src/services/centralized-coin'
-import { getNumberOfPages } from 'src/services/centralized-coin'
+import { getNumberOfPages, useTransactionPage } from 'src/services/centralized-coin'
 
 // --
 
@@ -15,7 +14,7 @@ function useNavigation() {
   })
   
   const last = React.useCallback(() => getNumberOfPages().then(
-    (value: number) => { setPage(page => value)
+    (value: number) => { setPage(value)
   }), [])
 
   const next = React.useCallback(() => setPage(page => page + 1), [])
@@ -24,7 +23,7 @@ function useNavigation() {
     []
   )
 
-  const first = React.useCallback(() => setPage(page => 0), [])
+  const first = React.useCallback(() => setPage(0), [])
 
   const { isLoading, isFetching } = useTransactionPage(page)
   return {

--- a/src/client/components/PageNavigation.tsx
+++ b/src/client/components/PageNavigation.tsx
@@ -3,7 +3,7 @@ import { queryTypes, useQueryState } from 'next-usequerystate'
 import React from 'react'
 import { FiArrowLeft, FiArrowRight } from 'react-icons/fi'
 import { MdFirstPage, MdLastPage} from 'react-icons/md'
-import { getNumberOfPages, useTransactionPage } from 'src/services/centralized-coin'
+import { getLastPageNumber, useTransactionPage } from 'src/services/centralized-coin'
 
 // --
 
@@ -13,7 +13,7 @@ function useNavigation() {
     ...queryTypes.integer
   })
   
-  const last = React.useCallback(() => getNumberOfPages().then(
+  const last = React.useCallback(() => getLastPageNumber().then(
     (value: number) => { setPage(value)
   }), [])
 

--- a/src/client/components/PageNavigation.tsx
+++ b/src/client/components/PageNavigation.tsx
@@ -2,7 +2,9 @@ import { Button, Flex, FlexProps, Text } from '@chakra-ui/react'
 import { queryTypes, useQueryState } from 'next-usequerystate'
 import React from 'react'
 import { FiArrowLeft, FiArrowRight } from 'react-icons/fi'
+import { MdFirstPage, MdLastPage} from 'react-icons/md'
 import { useTransactionPage } from 'src/services/centralized-coin'
+import { getNumberOfPages } from 'src/services/centralized-coin'
 
 // --
 
@@ -11,17 +13,26 @@ function useNavigation() {
     defaultValue: 0,
     ...queryTypes.integer
   })
+  
+  const last = React.useCallback(() => getNumberOfPages().then(
+    (value: number) => { setPage(page => value)
+  }), [])
 
   const next = React.useCallback(() => setPage(page => page + 1), [])
   const prev = React.useCallback(
     () => setPage(page => Math.max(0, page - 1)),
     []
   )
+
+  const first = React.useCallback(() => setPage(page => 0), [])
+
   const { isLoading, isFetching } = useTransactionPage(page)
   return {
     page,
+    last,
     next,
     prev,
+    first,
     setPage,
     isLoading: isLoading || isFetching
   }
@@ -32,9 +43,20 @@ function useNavigation() {
 export interface PageNavigationProps extends FlexProps {}
 
 export const PageNavigation: React.FC<PageNavigationProps> = ({ ...props }) => {
-  const { page, next, prev, isLoading } = useNavigation()
+
+  const { page, last, next, prev, first, isLoading } = useNavigation()
   return (
     <Flex alignItems="center" {...props}>
+      <Button
+        onClick={first}
+        isDisabled={page === 0}
+        leftIcon={<MdFirstPage />}
+        isLoading={isLoading}
+        w="7.5rem"
+      >
+        {' '}
+        First
+      </Button>
       <Button
         onClick={prev}
         isDisabled={page === 0}
@@ -55,6 +77,14 @@ export const PageNavigation: React.FC<PageNavigationProps> = ({ ...props }) => {
         isLoading={isLoading}
       >
         Next
+      </Button>
+      <Button
+        onClick={last}
+        rightIcon={<MdLastPage />}
+        w="7.5rem"
+        isLoading={isLoading}
+      >
+        Last
       </Button>
     </Flex>
   )

--- a/src/services/centralized-coin.ts
+++ b/src/services/centralized-coin.ts
@@ -105,12 +105,12 @@ export function usePreloadNeighbouringPages(pageNumber: number) {
   }, [pageNumber])
 }
 
-export async function getNumberOfPages() : Promise<number> {
+export async function getLastPageNumber() : Promise<number> {
   const res = await fetch(
     `https://www.centralized-coin.com/api/stats`
   )
   const data = await res.json()
   const transactionsPerPage = 50;
   const numberOfTransactions: number = data.count
-  return Math.floor(numberOfTransactions/ transactionsPerPage);
+  return Math.ceil(numberOfTransactions/ transactionsPerPage);
 }

--- a/src/services/centralized-coin.ts
+++ b/src/services/centralized-coin.ts
@@ -104,3 +104,13 @@ export function usePreloadNeighbouringPages(pageNumber: number) {
     )
   }, [pageNumber])
 }
+
+export async function getNumberOfPages() : Promise<number> {
+  const res = await fetch(
+    `https://www.centralized-coin.com/api/stats`
+  )
+  const data = await res.json()
+  const transactionsPerPage = 50;
+  const numberOfTransactions: number = data.count
+  return Math.floor(numberOfTransactions/ transactionsPerPage);
+}


### PR DESCRIPTION
Can now navigate to first and last page via two additional buttons. Need some limitation to prevent navigation past the last page?

Closes #3.