### PR TITLE
Fix last page calculation

### DIFF
--- a/src/services/centralized-coin.ts
+++ b/src/services/centralized-coin.ts
@@ -112,5 +112,5 @@ export async function getLastPageNumber() : Promise<number> {
   const data = await res.json()
   const transactionsPerPage = 50;
   const numberOfTransactions: number = data.count
-  return Math.ceil(numberOfTransactions/ transactionsPerPage);
+  return Math.floor(numberOfTransactions/ transactionsPerPage);
 }


### PR DESCRIPTION
Change in the pull request for https://github.com/franky47/centralized-coin-explorer/issues/3 incorrectly calculates the last page. This issue is confused by the fact that the api endpoint (https://www.centralized-coin.com/api/stats) to get the transaction count does not match the number of transactions shown in the transaction explorer. 

The transaction page numbers are zero indexed so it must use Math.floor to round down rather than Math.ceil to round up. Imagine there are 60 transactions. page 0 has 50, page 1 has 10. Then 60 / 50 = 1.2, Math.ceil(1.2) = 2. But you really want page 1 (thanks to JR for this explanation). 